### PR TITLE
Give a better error with an invalid response

### DIFF
--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -1027,7 +1027,7 @@ class Pfurl():
             d_ret['remoteCheck']    = remoteCheck
             self.qprint(str(d_ret), comms = 'rx')
             if not d_ret['remoteCheck']['status']:
-                self.qprint('An error occurred while checking the remote server.',
+                self.qprint('An error occurred while checking the remote server. Sometimes using --httpResponseBodyParse will address this problem.',
                             comms = 'error')
                 d_ret['remoteCheck']['msg']     = "The remote path spec is invalid!"
                 b_OK        = False

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -944,13 +944,17 @@ class Pfurl():
                                                     fileToPush  = str_fileToProcess,
                                                     encoding    = str_encoding)
                                                     # d_ret       = d_ret)
-        d_ret['status'] = d_ret['remoteServer']['status']
-        d_ret['msg']    = d_ret['remoteServer']['msg']
 
         if b_cleanZip:
             self.qprint("Removing temp files...", comms = 'status')
             if os.path.isfile(str_zipFile):     os.remove(str_zipFile)
             if os.path.isfile(str_base64File):  os.remove(str_base64File)
+
+        if 'status' in d_ret['remoteServer']:
+            d_ret['status'] = d_ret['remoteServer']['status']
+            d_ret['msg']    = d_ret['remoteServer']['msg']
+        else:
+            raise Exception('Invalid Response')
 
         return d_ret
 


### PR DESCRIPTION
This gets rid of a message that says you are using a string for an index error when the response isn't a dict and also handles the local file cleanup before erroring.