### PR TITLE
Allow for versions of python > 3.5

### DIFF
--- a/bin/pfurl
+++ b/bin/pfurl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 #
 # (c) 2017 Fetal-Neonatal Neuroimaging & Developmental Science Center
 #                   Boston Children's Hospital

--- a/pfurl/dgmsocket.py
+++ b/pfurl/dgmsocket.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 # 
 # NAME
 #

--- a/pfurl/message.py
+++ b/pfurl/message.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 import  sys
 import  os

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 
 '''
 


### PR DESCRIPTION
Specifying the version as 3.5 doesn't allow for versions greater than 3.5.