### PR TITLE
adds the ability to enter whole web addresses with --url flag

### DIFF
--- a/bin/pfurl
+++ b/bin/pfurl
@@ -18,8 +18,8 @@ from    argparse            import RawTextHelpFormatter
 from    argparse            import ArgumentParser
 from    pfurl._colors       import Colors
 
-str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
-str_defPort = '5055'
+#str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostname())[2] if not ip.startswith("127.")][:1], [[(s.connect(('8.8.8.8', 53)), s.getsockname()[0], s.close()) for s in [socket.socket(socket.AF_INET, socket.SOCK_DGRAM)]][0][1]]) if l][0][0]
+#str_defPort = '5055'
 
 str_name    = 'pfurl'
 str_version = "1.3.16.0"
@@ -75,13 +75,6 @@ parser.add_argument(
     dest    = 'verb',
     default = 'POST',
     help    = 'REST verb.'
-)
-parser.add_argument(
-    '--http',
-    action  = 'store',
-    dest    = 'http',
-    default = '%s:%s' % (str_defIP, str_defPort),
-    help    = 'HTTP string: <IP>[:<port>]</some/path/>'
 )
 parser.add_argument(
     '--auth',
@@ -153,17 +146,43 @@ parser.add_argument(
     action  = 'store_true',
     default = False
 )
-
-
+parser.add_argument(
+    '--http',
+    action  = 'store',
+    dest    = 'http',
+    default = '',
+    help    = 'HTTP string: <IP>[:<port>]</some/path/>'
+)
+parser.add_argument(
+    '--url',
+    action = 'store',
+    dest   = 'url',
+    default= '',
+    help   = 'any web address'
+)
+ 
 args    = parser.parse_args()
+
+if args.http:
+    # if the user enters --http and --url
+    if args.url:
+        print("Error: You may only specify --url or --http, not both! Exiting")
+        sys.exit(2)
+    else:
+        print("Warning: The use of --http is deprecated and may not be supported in future updates")
+        args.url = args.http
+# no address specified, exit ---> Default pathing removed
+elif not args.url:
+    print("Error: No web address provided! Please refer to the README, or use the --man flag for help.")
+    sys.exit(2)
 
 if args.b_version:
     print("Version: %s" % str_version)
     sys.exit(1)
 
 pfurl  = pfurl.Pfurl(
+    url                         = args.url,
     msg                         = args.msg,
-    http                        = args.http,
     verb                        = args.verb,
     contentType                 = args.contentType,
     auth                        = args.auth,

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -94,15 +94,11 @@ class Pfurl():
                                             within      = self.__name__ 
                                             )
 
-        self.str_http                   = ""
-        self.str_ip                     = ""
-        self.str_port                   = ""
-        self.str_URL                    = ""
+        self.url                        = ""
         self.str_verb                   = ""
         self.str_msg                    = ""
         self.str_auth                   = ""
         self.d_msg                      = {}
-        self.str_protocol               = "http"
         self.pp                         = pprint.PrettyPrinter(indent=4)
         self.b_man                      = False
         self.str_man                    = ''
@@ -115,6 +111,10 @@ class Pfurl():
         self.str_contentType            = ''
         self.b_useDebug                 = False
         self.str_debugFile              = ''
+
+
+        #for deprecated projects --> this should be removed in future iterations
+        self.http                       = ''
 
         self.LC                         = 40
         self.RC                         = 40
@@ -129,12 +129,11 @@ class Pfurl():
                     self.d_msg              = json.loads(self.str_msg)
                 except:
                     pass
-            if key == 'http':                       self.httpStr_parse( http        = val)
+            if key == 'http':                       self.http                       = val
+            if key == 'url':                        self.url                        = val
             if key == 'auth':                       self.str_auth                   = val
             if key == 'verb':                       self.str_verb                   = val
             if key == 'contentType':                self.str_contentType            = val
-            if key == 'ip':                         self.str_ip                     = val
-            if key == 'port':                       self.str_port                   = val
             if key == 'b_quiet':                    self.b_quiet                    = val
             if key == 'b_raw':                      self.b_raw                      = val
             if key == 'b_oneShot':                  self.b_oneShot                  = val
@@ -149,6 +148,18 @@ class Pfurl():
             if key == 'desc':                       self.str_desc                   = val
 
         if self.b_quiet: self.dp.verbosity = -10
+
+        #allows deprecated programs to use the syntax and checks for certian corner cases where pfurl may fail or work unpredictably
+        if self.http:
+            if self.url:
+                print("pfurl: Error: You may only specify either url or http, not both! Exiting")
+                sys.exit(2)
+            else:
+                print("Warning: The use of http is deprecated and will be removed in future iterations")
+                self.url = self.http
+        elif not self.url:
+            print("pfurl: Error: No web address provided! Exiting!")
+            sys.exit(2)
 
         if self.b_useDebug:
             self.debug                  = Message(logTo = self.str_debugFile)
@@ -176,11 +187,7 @@ class Pfurl():
             self.dp.qprint('pfurl: Command line args = %s' % sys.argv)
             if self._startFromCLI and (sys.argv) == 1: sys.exit(1)
 
-            str_colon_port = ''
-            if self.str_port:
-                str_colon_port = ':' + self.str_port
-
-            self.col2_print("Will transmit to ",     '%s://%s%s' % (self.str_protocol, self.str_ip, str_colon_port))
+            self.col2_print("Will transmit to ",     '%s' % (self.url))
 
     def storage_resolveBasedOnKey(self, *args, **kwargs):
         """
@@ -276,17 +283,17 @@ class Pfurl():
             to a remote REST-like service: """ + Colors.GREEN + """
 
                  ./pfurl.py [--auth <username:passwd>] [--verb <GET/POST>]   \\
-                            --http <IP>[:<port>]</some/path/>
+                            --url ://[:]</some/path/>
 
             """ + Colors.WHITE + """
             Where --auth is an optional authorization to pass to the REST API,
-            --verb denotes the REST verb to use and --http specifies the REST URL.
+            --verb denotes the REST verb to use and --url specifies the REST url.
 
             Additionally, a 'message' described in JSON syntax can be pushed to the
             remote service, in the following syntax: """ + Colors.GREEN + """
 
                  pfurl     [--auth <username:passwd>] [--verb <GET/POST>]   \\
-                            --http <IP>[:<port>]</some/path/>               \\
+                            --url ://[:]</some/path/>               \\
                            [--msg <JSON-formatted-string>]
 
             """ + Colors.WHITE + """
@@ -294,7 +301,7 @@ class Pfurl():
             contextual syntax, for example:
             """ + Colors.GREEN + """
 
-                 pfurl      --verb POST --http %s:%s/api/v1/cmd/ --msg \\
+                 pfurl      --verb POST --url %s --msg \\
                                 '{  "action": "run",
                                     "meta": {
                                         "cmd":      "cal 7 1970",
@@ -305,7 +312,7 @@ class Pfurl():
                                 }'
 
 
-            """ % (self.str_ip, self.str_port) + Colors.CYAN + """
+            """ % (self.url) + Colors.CYAN + """
 
             The following specific action directives are directly handled by script:
             """ + "\n" + \
@@ -365,7 +372,7 @@ class Pfurl():
                 """ + Colors.YELLOW + """EXAMPLE:
                 """ + Colors.LIGHT_GREEN + """
                 
-                pfurl --verb POST --http %s:%s/api/v1/cmd/ --msg \\
+                pfurl --verb POST --url %s --msg \\
                     '{  "action": "pushPath",
                         "meta":
                             {
@@ -389,11 +396,11 @@ class Pfurl():
                                     }
                             }
                     }'
-                """ % (self.str_ip, self.str_port) + Colors.NO_COLOUR  + """
+                """ % (self.url) + Colors.NO_COLOUR  + """
                 """ + Colors.YELLOW + """ALTERNATE -- using copy/symlink:
                 """ + Colors.LIGHT_GREEN + """
                 
-                pfurl --verb POST --http %s:%s/api/v1/cmd/ --msg \\
+                pfurl --verb POST --url %s --msg \\
                     '{  "action": "pushPath",
                         "meta":
                             {
@@ -414,7 +421,7 @@ class Pfurl():
                                     }
                             }
                     }'
-                """ % (self.str_ip, self.str_port) + Colors.NO_COLOUR
+                """ % (self.url) + Colors.NO_COLOUR
 
         return str_manTxt
 
@@ -458,7 +465,7 @@ class Pfurl():
                 """ + Colors.YELLOW + """EXAMPLE -- using zip:
                 """ + Colors.LIGHT_GREEN + """
                 
-                pfurl --verb POST --http %s:%s/api/v1/cmd/ --msg \\
+                pfurl --verb POST --url %s --msg \\
                     '{  "action": "pullPath",
                         "meta":
                             {
@@ -482,11 +489,11 @@ class Pfurl():
                                     }
                             }
                     }'
-                """ % (self.str_ip, self.str_port) + Colors.NO_COLOUR + """
+                """ % (self.url) + Colors.NO_COLOUR + """
                 """ + Colors.YELLOW + """ALTERNATE -- using copy/symlink:
                 """ + Colors.LIGHT_GREEN + """
                 
-                pfurl --verb POST --http %s:%s/api/v1/cmd/ --msg \\
+                pfurl --verb POST --url %s/api/v1/cmd/ --msg \\
                     '{  "action": "pullPath",
                         "meta":
                             {
@@ -507,7 +514,7 @@ class Pfurl():
                                     }
                             }
                     }'
-                """ % (self.str_ip, self.str_port) + Colors.NO_COLOUR
+                """ % (self.url) + Colors.NO_COLOUR
 
         return str_manTxt
 
@@ -515,32 +522,20 @@ class Pfurl():
         """
         Just the core of the pycurl logic.
         """
-
-        str_ip              = self.str_ip
-        str_port            = self.str_port
         verbose             = 0
         d_msg               = {}
 
         for k,v in kwargs.items():
-            if k == 'ip':       str_ip      = v
-            if k == 'port':     str_port    = v
             if k == 'msg':      d_msg       = v
             if k == 'verbose':  verbose     = v
 
         response            = io.BytesIO()
 
-        str_query   = ''
-        if len(d_msg):
-            d_meta              = d_msg['meta']
-            str_query           = '?%s' % urllib.parse.urlencode(d_msg)
-
-        str_URL = "http://%s:%s%s%s" % (str_ip, str_port, self.str_URL, str_query)
-
-        self.dp.qprint(str_URL,
+        self.dp.qprint(self.url,
                     comms  = 'tx')
 
-        c                   = pycurl.Curl()
-        c.setopt(c.URL, str_URL)
+        c = pycurl.Curl()
+        c.setopt(c.URL, self.url)
         if verbose: c.setopt(c.VERBOSE, 1)
         c.setopt(c.FOLLOWLOCATION,  1)
         c.setopt(c.WRITEFUNCTION,   response.write)
@@ -884,16 +879,12 @@ class Pfurl():
         str_fileToProcess   = ""
         str_encoding        = "none"
         d_ret               = {}
-        str_ip              = self.str_ip
-        str_port            = self.str_port
         verbose             = 0
 
         for k,v in kwargs.items():
             if k == 'fileToPush':   str_fileToProcess   = v
             if k == 'encoding':     str_encoding        = v
             if k == 'd_ret':        d_ret               = v
-            if k == 'ip':           str_ip              = v
-            if k == 'port':         str_port            = v
             if k == 'verbose':      verbose             = v
 
         if len(self.str_jsonwrapper):
@@ -902,18 +893,12 @@ class Pfurl():
             str_msg         = json.dumps(d_msg)
         response            = io.BytesIO()
 
-
-        str_colon_port = ''
-        if str_port:
-            str_colon_port = ':' + str_port
-
-        self.qprint("http://%s%s%s" % (str_ip, str_colon_port, self.str_URL) + '\n '+ str(d_msg),
+        self.qprint(self.url + '\n '+ str(d_msg),
                     comms  = 'tx')
 
         c = pycurl.Curl()
         c.setopt(c.POST, 1)
-        # c.setopt(c.URL, "http://%s:%s/api/v1/cmd/" % (str_ip, str_port))
-        c.setopt(c.URL, "http://%s:%s%s" % (str_ip, str_port, self.str_URL))
+        c.setopt(c.URL, self.url)
         if str_fileToProcess:
             self.dp.qprint("Building form-based multi-part message...", comms = 'status')
             fread               = open(str_fileToProcess, "rb")
@@ -933,7 +918,6 @@ class Pfurl():
             #          )
             c.setopt(c.POSTFIELDS, str_msg)
         if verbose:                     c.setopt(c.VERBOSE, 1)
-        # print(self.str_contentType)
         if len(self.str_contentType):   c.setopt(c.HTTPHEADER, ['Content-type: %s' % self.str_contentType])
         c.setopt(c.WRITEFUNCTION,   response.write)
         if len(self.str_auth):
@@ -996,18 +980,12 @@ class Pfurl():
             if k == 'd_ret':        d_ret               = v
 
         d_meta              = d_msg['meta']
-        str_ip              = self.str_ip
-        str_port            = self.str_port
         if 'remote' in d_meta:
             d_remote            = d_meta['remote']
-            if 'ip' in d_remote:    str_ip      = d_remote['ip']
-            if 'port' in d_remote:  str_port    = d_remote['port']
-
+            
         d_ret               = self.push_core(   d_msg,
                                                 fileToPush  = str_fileToProcess,
-                                                encoding    = str_encoding,
-                                                ip          = str_ip,
-                                                port        = str_port
+                                                encoding    = str_encoding
                                             )
         return d_ret
 
@@ -1023,13 +1001,6 @@ class Pfurl():
         str_localPath       = d_local['path']
 
         d_remote            = d_meta['remote']
-        str_ip              = self.str_ip
-        str_port            = self.str_port
-        if 'ip' in d_remote:
-            str_ip          = d_remote['ip']
-        if 'port' in d_remote:
-            str_port        = d_remote['port']
-
         str_mechanism       = ""
         str_encoding        = ""
         str_archive         = ""
@@ -1283,19 +1254,6 @@ class Pfurl():
 
         return self.pathOp_do(d_msg, action = 'pull')
 
-    def httpStr_parse(self, **kwargs):
-
-        for k,v in kwargs.items():
-            if k == 'http':     self.str_http   = v
-
-        # Split http string into IP:port and URL
-        path_split_url = self.str_http.split('/')
-        str_IPport          = path_split_url[0]
-        self.str_URL        = '/' + '/'.join(path_split_url[1:])
-        host_port_pair = str_IPport.split(':')
-        self.str_ip = host_port_pair[0]
-        if len(host_port_pair) > 1:
-            self.str_port = host_port_pair[1]
 
     def httpResponse_bodyParse(self, **kwargs):
         """
@@ -1330,8 +1288,8 @@ class Pfurl():
             if key == 'msg':
                 self.str_msg    = val
                 self.d_msg      = json.loads(self.str_msg)
-            if key == 'http':       self.httpStr_parse( http    = val)
-            if key == 'verb':       self.str_verb               = val
+            if key == 'url':        self.url    = val
+            if key == 'verb':       self.str_verb   = val
 
         if len(self.str_msg):
             if 'action' in self.d_msg: str_action  = self.d_msg['action']


### PR DESCRIPTION
@danmcp @rudolphpienaar 

Tested on my local system. It is able to send hello requests and commands to pman and pfioh. Let me know if you want more in depth testing.

I added logic to allow people to still use the old syntax, however it will print a warning telling them their code is deprecated if they do. I also added checks for corner cases to make sure people weren't trying to set both a url and http and then getting unexpected outcomes. The code will exit with code 2 for incorrect syntax, and will print the error message: 

Error: You may only specify --url or --http, not both! Exiting

I also removed the default routing you had set in the parser. I think that this should be very literal, and people should have to specify their intended path, or have the program exit. Otherwise it might confuse them, or ping a server unintentionally. Now when you don't give pfurl a web address it gives the following error statement: 

Error: No web address provided! Exiting!