### PR TITLE
Enables pfurl to send requests to servers that require Bearer Token Authorization [safe to merge]

### DIFF
--- a/bin/pfurl
+++ b/bin/pfurl
@@ -81,7 +81,7 @@ parser.add_argument(
     action  = 'store',
     dest    = 'http',
     default = '%s:%s' % (str_defIP, str_defPort),
-    help    = 'HTTP string: <IP>[:<port>]</some/path/>'
+    help    = 'HTTP string: http://<IP>[:<port>]</some/path/>'
 )
 parser.add_argument(
     '--auth',
@@ -153,8 +153,20 @@ parser.add_argument(
     action  = 'store_true',
     default = False
 )
-
-
+parser.add_argument(
+    '--unverifiedCerts',
+    help    = "Allows you to send https requests with self signed ssl certificates",
+    dest    = 'unverifiedCerts',
+    action  = 'store_true',
+    default = False
+)
+parser.add_argument(
+    '--authToken',
+    help    = 'Send a token for authentication with your http request',
+    dest    = 'authToken',
+    action  = 'store',
+    default = ''
+)
 args    = parser.parse_args()
 
 if args.b_version:
@@ -176,7 +188,9 @@ pfurl  = pfurl.Pfurl(
     desc                        = str_desc,
     name                        = str_name,
     version                     = str_version,
-    startFromCLI                = True
+    startFromCLI                = True,
+    unverifiedCerts             = args.unverifiedCerts,
+    authToken                   = args.authToken
     )
 
 if not args.jsonpprintindent:


### PR DESCRIPTION
Things to note:
- this patch also enables pfurl to send messages via https
    - **this is still under development**, but does not affect the behavior of the library
    - the interface has not been changed to enable this, instead, the full url can be passed in the --http flag with the syntax:  --http https://<address> and it will parse the protocol [http | https] from the url string.
- A command line flag --authToken has been added to enable debugging, this is not for production use! 
    - Syntax: --authToken \<plain text token\>
- In python scripts, tokens are passed via the authToken parameter, as seen in line 193 of /bin/pfurl

@danmcp @rudolphpienaar 