### PR TITLE
Addressing str_localPath undefined error while pushing files to pfioh

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -3,4 +3,4 @@
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
   </component>
-</project>
+</project> 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ##################
-pfurl - v2.2.4.2
+pfurl - v2.2.4.4
 ##################
 
 .. image:: https://badge.fury.io/py/pfurl.svg

--- a/bin/pfurl
+++ b/bin/pfurl
@@ -24,7 +24,7 @@ str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostn
 str_defPort = '5055'
 
 str_name    = 'pfurl'
-str_version = "2.2.4.2"
+str_version = "2.2.4.4"
 str_desc    = Colors.CYAN + """
 
         __            _

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -1158,7 +1158,7 @@ class Pfurl():
             Logic here handles file/dir issues, and dir naming issues (such
             as sanity checking trailing '/' chars).
             """
-            nonlocal str_fileToProcess, str_zipFile, d_ret
+            nonlocal str_fileToProcess, str_zipFile, str_localPath, d_ret 
 
             self.dp.qprint(
                             "Zipping target '%s'..." % str_localPath,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
       name             =   'pfurl',
-      version          =   '2.2.4.2',
+      version          =   '2.2.4.4',
       description      =   '(Python) Path-File URL comms',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
Previously, pfioh push in the ChRIS integration test returned an error within pfurl since the `str_localPath`  is not defined as a nonlocal variable. This fix resolves that error and enables pfioh push to run succesfully.