### PR TITLE
Deprecate --httpResponseBodyParse

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ##################
-pfurl - v2.2.4.6
+pfurl - v2.3.0.0
 ##################
 
 .. image:: https://badge.fury.io/py/pfurl.svg
@@ -157,10 +157,6 @@ For the most up-to-date usage of ``pfurl``, consult the `pfurl wiki page <https:
         [--jsonpprintindent <indent>]
         If specified, print return JSON payload from remote service using
         <indent> indentation.
-
-        [--httpResponseBodyParse]
-        If specified, interpret the return payload as encapsulated in an
-        http response.
 
         [--unverifiedCerts]
         If specified, allows transmission of https requests with self signed SSL

--- a/bin/pfurl
+++ b/bin/pfurl
@@ -24,7 +24,7 @@ str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostn
 str_defPort = '5055'
 
 str_name    = 'pfurl'
-str_version = "2.2.4.6"
+str_version = "2.3.0.0"
 str_desc    = Colors.CYAN + """
 
         __            _
@@ -179,10 +179,6 @@ def synopsis(ab_shortOnly = False):
         If specified, print return JSON payload from remote service using
         <indent> indentation.
 
-        [--httpResponseBodyParse]
-        If specified, interpret the return payload as encapsulated in an
-        http response.
-
         [--unverifiedCerts]
         If specified, allows transmission of https requests with self signed SSL
         certificates.
@@ -330,7 +326,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '--httpResponseBodyParse',
-    help    = 'if specified, assume full HTTP responses and parse only the body',
+    help    = 'deprecated option',
     dest    = 'b_httpResponseBodyParse',
     action  = 'store_true',
     default = False
@@ -377,6 +373,12 @@ if args.b_version:
     print("Version: %s" % str_version)
     sys.exit(1)
 
+if args.b_httpResponseBodyParse:
+    print('deprecated option: --httpResponseBodyParse. '
+          'Do not use as of 2020-11-09, see '
+          'https://github.com/FNNDSC/pfioh/pull/70')
+    sys.exit(1)
+
 pfurl  = pfurl.Pfurl(
     msg                         = args.msg,
     http                        = args.http,
@@ -387,7 +389,6 @@ pfurl  = pfurl.Pfurl(
     b_raw                       = args.b_raw,
     b_quiet                     = args.b_quiet,
     b_oneShot                   = args.b_oneShot,
-    b_httpResponseBodyParse     = args.b_httpResponseBodyParse,
     jsonwrapper                 = args.jsonwrapper,
     man                         = args.man,
     desc                        = str_desc,
@@ -397,7 +398,7 @@ pfurl  = pfurl.Pfurl(
     verbosity                   = args.verbosity,
     unverifiedCerts             = args.unverifiedCerts,
     authToken                   = args.authToken
-    )
+)
 
 str_response  = pfurl()
 

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -37,7 +37,6 @@ import  datetime
 import  zipfile
 import  uuid
 import  base64
-import  yaml
 import  shutil
 import  inspect
 import  glob
@@ -100,7 +99,6 @@ class Pfurl():
         self.b_quiet                    = False
         self.b_raw                      = False
         self.b_oneShot                  = False
-        self.b_httpResponseBodyParse    = False
         self.auth                       = ''
         self.str_jsonwrapper            = ''
         self.str_contentType            = ''
@@ -137,7 +135,6 @@ class Pfurl():
             if key == 'b_quiet':                    self.b_quiet                    = val
             if key == 'b_raw':                      self.b_raw                      = val
             if key == 'b_oneShot':                  self.b_oneShot                  = val
-            if key == 'b_httpResponseBodyParse':    self.b_httpResponseBodyParse    = val
             if key == 'man':                        self.str_man                    = val
             if key == 'jsonwrapper':                self.str_jsonwrapper            = val
             if key == 'useDebug':                   self.b_useDebug                 = val
@@ -1038,12 +1035,7 @@ class Pfurl():
                         comms   = 'status')
             if self.b_raw:
                 try:
-                    if self.b_httpResponseBodyParse:
-                        d_ret   = json.loads(
-                                self.httpResponse_bodyParse(response = response)
-                        )
-                    else:
-                        d_ret   = json.loads(response)
+                    d_ret   = json.loads(response)
                 except:
                     d_ret           = response
             else:
@@ -1376,7 +1368,7 @@ class Pfurl():
             d_ret['remoteCheck']    = remoteCheck
             self.dp.qprint("d_ret:\n%s" % self.pp.pformat(d_ret).strip(), level = 1, comms ='rx')
             if not d_ret['remoteCheck']['status']:
-                self.dp.qprint('An error occurred while checking the remote server. Sometimes using --httpResponseBodyParse will address this problem.',
+                self.dp.qprint('An error occurred while checking the remote server.',
                             level = 1, comms ='error')
                 d_ret['remoteCheck']['msg']     = "The remote path spec is invalid!"
                 b_OK                            = False
@@ -1475,25 +1467,6 @@ class Pfurl():
         self.str_ip = host_port_pair[0]
         if len(host_port_pair) > 1:
             self.str_port = host_port_pair[1]
-
-    def httpResponse_bodyParse(self, **kwargs):
-        """
-        Returns the *body* from a http response.
-
-        :param kwargs: response = <string>
-        :return: the <body> from the http <string>
-        """
-
-        str_response    = ''
-        for k,v in kwargs.items():
-            if k == 'response': str_response    = v
-        try:
-            str_body        = str_response.split('\r\n\r\n')[1]
-            d_body          = yaml.load(str_body, Loader=yaml.FullLoader)
-            str_body        = json.dumps(d_body)
-        except:
-            str_body        = str_response
-        return str_body
 
     def __call__(self, *args, **kwargs):
         """

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
       name             =   'pfurl',
-      version          =   '2.2.4.6',
+      version          =   '2.3.0.0',
       description      =   '(Python) Path-File URL comms',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
After https://github.com/FNNDSC/pfioh/pull/70 has been merged, there is no use for `--httpResponseBodyParse`, which only exists to accommodate for the misplaced HTTP headers bug in `pfioh<=2.2.0.8`.

The code and documentation for `--httpResponseBodyParse` is removed. Using the CLI flag throws an error. Passing `b_httpResponseBodyParse` as part of `**kwargs` to `pfurl.Pfurl` has no effect.