### PR TITLE
Fix crash without --raw

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ##################
-pfurl - v2.3.0.0
+pfurl - v2.3.0.1
 ##################
 
 .. image:: https://badge.fury.io/py/pfurl.svg

--- a/bin/pfurl
+++ b/bin/pfurl
@@ -24,7 +24,7 @@ str_defIP   = [l for l in ([ip for ip in socket.gethostbyname_ex(socket.gethostn
 str_defPort = '5055'
 
 str_name    = 'pfurl'
-str_version = "2.3.0.0"
+str_version = "2.3.0.1"
 str_desc    = Colors.CYAN + """
 
         __            _

--- a/pfurl/pfurl.py
+++ b/pfurl/pfurl.py
@@ -1043,7 +1043,7 @@ class Pfurl():
                     d_ret['stdout']     = json.loads(response)
                 except:
                     d_ret['stdout']     = response
-                if 'status' in d_ret['stdout']:
+                if isinstance(d_ret['stdout'], dict) and 'status' in d_ret['stdout']:
                     d_ret['status']     = d_ret['stdout']['status']
                 d_ret['msg']            = 'push OK.'
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def readme():
 
 setup(
       name             =   'pfurl',
-      version          =   '2.3.0.0',
+      version          =   '2.3.0.1',
       description      =   '(Python) Path-File URL comms',
       long_description =   readme(),
       author           =   'Rudolph Pienaar',


### PR DESCRIPTION
Previously if the data is not _JSON_ but instead _plaintext_ string containing the substring "status", and the flag `--raw` is not given, `curl_responseProcess` would attempt to index a string as a `dict`.

e.g. if

```
curl --data lol http://example.com
```

Were to produce a string "this string contains the word status in it"

then the analogous

```
pfurl --verb POST --msg lol --http http://example.com 
```

would crash, yet

```
pfurl --verb POST --msg lol --http http://example.com --raw
```

would work.

This PR fixes the described bug.